### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ WANT_NEW_API = 1
 CORE_DEFINE := -DWANT_GBA_EMU
 
 TARGET_NAME := mednafen_$(core)_libretro
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 ifeq ($(platform), unix)
    TARGET := $(TARGET_NAME).so

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -4,6 +4,11 @@ FRONTEND_SUPPORTS_RGB565 = 1
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 ifeq ($(TARGET_ARCH),arm)
 ANDROID_FLAGS := -DANDROID_ARM
 LOCAL_ARM_MODE := arm

--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3784,7 +3784,10 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    memset(info, 0, sizeof(*info));
    info->library_name     = MEDNAFEN_CORE_NAME;
-   info->library_version  = MEDNAFEN_CORE_VERSION;
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version  = MEDNAFEN_CORE_VERSION GIT_VERSION;
    info->need_fullpath    = true;
    info->valid_extensions = MEDNAFEN_CORE_EXTENSIONS;
    info->block_extract    = false;


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.