### PR TITLE
Fix need_fullpath value in libretro API

### DIFF
--- a/libretro.cpp
+++ b/libretro.cpp
@@ -3960,7 +3960,7 @@ void retro_get_system_info(struct retro_system_info *info)
 #define GIT_VERSION ""
 #endif
    info->library_version  = MEDNAFEN_CORE_VERSION GIT_VERSION;
-   info->need_fullpath    = false;
+   info->need_fullpath    = true;
    info->valid_extensions = MEDNAFEN_CORE_EXTENSIONS;
    info->block_extract    = false;
 }


### PR DESCRIPTION
This core assumes a full path is provided and does not handle the NULL indicator properly: https://github.com/libretro/beetle-gba-libretro/blob/f41ee5c/libretro.cpp#L3794